### PR TITLE
split action code and make get request

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import Cart from "./components/Cart/Cart";
 import Layout from "./components/Layout/Layout";
 import Products from "./components/Shop/Products";
 import Notification from "./components/Notification/Notification";
-import { sendCartData } from "./store/cart-slice";
+import { sendCartData, fetchCartData } from "./store/cart-actions";
 
 let isInitial = true;
 
@@ -14,6 +14,10 @@ const App = () => {
   const showCart = useSelector((state) => state.ui.cartIsVisible);
   const cart = useSelector((state) => state.cart);
   const notification = useSelector((state) => state.ui.notification);
+
+  useEffect(() => {
+    dispatch(fetchCartData());
+  }, [dispatch]);
 
   useEffect(() => {
     if (isInitial) {

--- a/src/store/cart-actions.js
+++ b/src/store/cart-actions.js
@@ -1,0 +1,79 @@
+import { uiActions } from "./ui-slice";
+import { cartActions } from "./cart-slice";
+
+export const fetchCartData = () => {
+  return async (dispatch) => {
+    const fetchData = async () => {
+      const response = await fetch(
+        "https://react-hooks-fe144-default-rtdb.asia-southeast1.firebasedatabase.app/cart.json"
+      );
+
+      if (!response.ok) {
+        throw new Error("Loading fail.");
+      }
+
+      const data = await response.json();
+
+      return data;
+    };
+
+    try {
+      const cartData = await fetchData();
+      dispatch(cartActions.replaceCart(cartData));
+    } catch (error) {
+      dispatch(
+        uiActions.showNotification({
+          status: "error",
+          title: "Error",
+          message: "Fetching Data Fail.",
+        })
+      );
+    }
+  };
+};
+
+export const sendCartData = (cart) => {
+  return async (dispatch) => {
+    dispatch(
+      uiActions.showNotification({
+        status: "pending",
+        title: "Sending...",
+        message: "Sending cart data",
+      })
+    );
+
+    const sendRequest = async () => {
+      const response = await fetch(
+        "https://react-hooks-fe144-default-rtdb.asia-southeast1.firebasedatabase.app/cart.json",
+        {
+          method: "PUT",
+          body: JSON.stringify(cart),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Sending cart data fail.");
+      }
+    };
+
+    try {
+      await sendRequest();
+
+      dispatch(
+        uiActions.showNotification({
+          status: "success",
+          title: "Success",
+          message: "Send cart data successfully,",
+        })
+      );
+    } catch (error) {
+      dispatch(
+        uiActions.showNotification({
+          status: "error",
+          title: "error",
+          message: "Sending cart data failed.",
+        })
+      );
+    }
+  };
+};

--- a/src/store/cart-slice.js
+++ b/src/store/cart-slice.js
@@ -1,7 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-import { uiActions } from "./ui-slice";
-
 const cartSlice = createSlice({
   name: "cart",
   initialState: { items: [], totalQuantity: 0 },
@@ -44,51 +42,7 @@ const cartSlice = createSlice({
 });
 
 // ActionCreator.
-export const sendCartData = (cart) => {
-  return async (dispatch) => {
-    dispatch(
-      uiActions.showNotification({
-        status: "pending",
-        title: "Sending...",
-        message: "Sending cart data",
-      })
-    );
 
-    const sendRequest = async () => {
-      const response = await fetch(
-        "https://react-hooks-fe144-default-rtdb.asia-southeast1.firebasedatabase.app/cart.json",
-        {
-          method: "PUT",
-          body: JSON.stringify(cart),
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error("Sending cart data fail.");
-      }
-    };
-
-    try {
-      await sendRequest();
-
-      dispatch(
-        uiActions.showNotification({
-          status: "success",
-          title: "Success",
-          message: "Send cart data successfully,",
-        })
-      );
-    } catch (error) {
-      dispatch(
-        uiActions.showNotification({
-          status: "error",
-          title: "error",
-          message: "Sending cart data failed.",
-        })
-      );
-    }
-  };
-};
 
 export const cartActions = cartSlice.actions;
 


### PR DESCRIPTION
- actionCreator를 사용함에 따라 길어진 코드를 나눈다.
- 기존 actionCreator는 Slice의 최하단에 따로 작성하였다.
- 이렇게 하면 reducer와 actionCreator가 한 파일 내에 작성되므로 매우 길어진다.
- 따라서 actionCreator는 따로 분리하고 사용처에서 import 하는 식으로 사용한다.
- 굳이 actionCreator를 쓰는 이유는 아직도 모르겠다. 그냥 lean code를 유지하기 위함으로 보인다. 