### PR TITLE
prevent init request

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ let isInitial = true;
 
 const App = () => {
   const dispatch = useDispatch();
+
   const showCart = useSelector((state) => state.ui.cartIsVisible);
   const cart = useSelector((state) => state.cart);
   const notification = useSelector((state) => state.ui.notification);
@@ -25,7 +26,9 @@ const App = () => {
       return;
     }
 
-    dispatch(sendCartData(cart));
+    if (cart.changed) {
+      dispatch(sendCartData(cart));
+    }
   }, [cart, dispatch]);
 
   return (

--- a/src/store/cart-actions.js
+++ b/src/store/cart-actions.js
@@ -19,7 +19,13 @@ export const fetchCartData = () => {
 
     try {
       const cartData = await fetchData();
-      dispatch(cartActions.replaceCart(cartData));
+      dispatch(
+        cartActions.replaceCart({
+          items: cartData.items || [],
+          totalQuantity: cartData.totalQuantity,
+          changed: cartData.changed,
+        })
+      );
     } catch (error) {
       dispatch(
         uiActions.showNotification({
@@ -47,7 +53,11 @@ export const sendCartData = (cart) => {
         "https://react-hooks-fe144-default-rtdb.asia-southeast1.firebasedatabase.app/cart.json",
         {
           method: "PUT",
-          body: JSON.stringify(cart),
+          body: JSON.stringify({
+            items: cart.items,
+            totalQuantity: cart.totalQuantity,
+            changed: cart.changed,
+          }),
         }
       );
 

--- a/src/store/cart-slice.js
+++ b/src/store/cart-slice.js
@@ -2,7 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 
 const cartSlice = createSlice({
   name: "cart",
-  initialState: { items: [], totalQuantity: 0 },
+  initialState: { items: [], totalQuantity: 0, changed: false },
   reducers: {
     replaceCart(state, action) {
       state.totalQuantity = action.payload.totalQuantity;
@@ -12,6 +12,7 @@ const cartSlice = createSlice({
       const newItem = action.payload;
       const existingItem = state.items.find((item) => item.id === newItem.id);
       state.totalQuantity++;
+      state.changed = true;
 
       if (!existingItem) {
         state.items.push({


### PR DESCRIPTION
- 앱이 최초 실행될 시 useEffect에 의해 PUT 요청이 실행되었다.
- 앱이 최초 실행될 시 fetch를 통해 cart의 data만 가져오는 것이 바람직하다.
- 따라서 상태 관리를 위한 initial state를 정하고 이 값에 따라 요청의 실행 여부를 제어한다.

- 앱에 데이터를 가져오는 원리는 다음과 같다.
0. 앱이 실행된다.
1. Redux에 의해 initial state가 정해진다.
2. useEffect에 의해 fetch가 실행되고 데이터를 가져온다.
3. 가져온 데이터가 기존의 initial state를 replace한다. 이에 대한 메서드를 만들어 두었다.
4. DB로부터 가져온 정보를 열람할 수 있게 된다.

이 과정에서 의문이 있었던 점은 changed 프로퍼티에 대한 것이다. 
add 또는 remove가 일어날 때 이 state는 true로 바뀐다. 
하지만 이 값이 false로 바뀌는 코드는 한 줄도 없다.
그렇다면 dispatch에 지속적으로 변화가 일어난다는 뜻인지?
이 부분을 다시 확인해볼 필요가 있다. 